### PR TITLE
feat: Take passes state to Shoot when confirm button is clicked

### DIFF
--- a/src/__tests__/Shoot.test.js
+++ b/src/__tests__/Shoot.test.js
@@ -67,7 +67,29 @@ describe("Shoot", () => {
   describe("confirm take button", () => {
     beforeEach(() => {
       shoot.find(".new-take-btn").simulate("click");
-      shoot.instance().confirmTake();
+      const testID = 1
+      const testTake = {
+        "scene": 1,
+        "shot": 2,
+        "takeNumber": 3,
+        "description": "Aerial",
+        "goodTake": true,
+        "notes": "Test Notes"
+      }
+      shoot.instance().confirmTake(testID, testTake);
+    });
+
+    it("updates takeDetails with details from confirmed take", () => {
+      const testDetails = {
+        "takeId": 1,
+        "scene": 1,
+        "shot": 2,
+        "takeNumber": 3,
+        "description": "Aerial",
+        "goodTake": true,
+        "notes": "Test Notes"
+      }
+      expect(shoot.state().takeDetails[0]).toEqual(testDetails);
     });
 
     it("adds a new take to the page", () => {

--- a/src/components/Shoot.js
+++ b/src/components/Shoot.js
@@ -9,10 +9,11 @@ class Shoot extends Component {
 
     this.state = {
       takes: [],
+      takeDetails: [],
       title: ""
     }
   }
-
+  
   addTake = () => {
     const takes = [...this.state.takes];
     const ids = this.state.takes.map(take => take.props.id);
@@ -23,7 +24,23 @@ class Shoot extends Component {
     this.setState({ takes })
   }
 
-  confirmTake = () => {
+  confirmTake = (takeID, take) => {
+
+    const takeDetails = [...this.state.takeDetails]
+
+    const currentTake = {
+      "takeId": takeID,
+      "scene": take.scene,
+      "shot": take.shot,
+      "takeNumber": take.takeNumber,
+      "description": take.description,
+      "goodTake": take.goodTake,
+      "notes": take.notes
+    }
+
+    takeDetails.push(currentTake)
+
+    this.setState({ takeDetails })
     this.addTake();
   }
 

--- a/src/components/Take.js
+++ b/src/components/Take.js
@@ -81,7 +81,7 @@ class Take extends Component {
           variant="contained" 
           color="primary" 
           className="confirm-btn"
-          onClick={() => this.props.confirmTake()}
+          onClick={() => this.props.confirmTake(this.props.id, this.state)}
         >
           <DoneIcon className="confirm-icon" />
         </Button>


### PR DESCRIPTION
When the confirmation button is clicked on an individual Take, it's details are passed into `this.props.confirmTake` this executes the `confirmTake()` function on Shoot which in turn updates its state with the relevant details.

This allows details of all the Takes in a shoot to be accessed in one place.  