### PR TITLE
feat: deleting a take will remove its details from Shoot's state

### DIFF
--- a/src/__tests__/Shoot.test.js
+++ b/src/__tests__/Shoot.test.js
@@ -55,11 +55,27 @@ describe("Shoot", () => {
       
     beforeEach(() => {
       shoot.find(".new-take-btn").simulate("click");
-      shoot.instance().removeTake(1);
     });
 
     it("removes the Take from `state`", () => {
+      shoot.instance().removeTake(1);
       expect(shoot.state().takes).toEqual([]);
+    });
+
+    it("removes the take's details from takeDetails", () => {
+      const testID = 1
+      const testTake = {
+        "scene": 1,
+        "shot": 2,
+        "takeNumber": 3,
+        "description": "Aerial",
+        "goodTake": true,
+        "notes": "Test Notes"
+      }
+      shoot.instance().confirmTake(testID, testTake);
+
+      shoot.instance().removeTake(1);
+      expect(shoot.state().takeDetails[0]).toEqual(expect.not.objectContaining(testTake));
     });
 
   });

--- a/src/components/Shoot.js
+++ b/src/components/Shoot.js
@@ -46,7 +46,8 @@ class Shoot extends Component {
 
   removeTake = id => {
     const takes = this.state.takes.filter(take => take.props.id !== id);
-    this.setState({ takes });
+    const takeDetails = this.state.takeDetails.filter(take => take.takeId !== id);
+    this.setState({ takes, takeDetails });
   }
 
   displayTakes = () => {


### PR DESCRIPTION
`removeTake()` filters `this.state.takeDetails` and removes the take with the matching `takeId`